### PR TITLE
Added FuelType to hexonvehicle

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"time"
 )
@@ -68,6 +69,7 @@ func (c *Client) CreateVehicle(vehicle Vehicle) (*APIResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+	log.Println(req)
 	return c.send(req)
 }
 
@@ -83,6 +85,8 @@ func (c *Client) PublishVehicle(vin, sitecode string) (*APIResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+	log.Println(msg)
+	log.Println(req)
 	return c.send(req)
 }
 

--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/http/httputil"
 	"time"
 )
 
@@ -62,6 +63,16 @@ type Client struct {
 	http     http.Client
 }
 
+// Dump request for printing and testing
+func DumpRequest(w http.ResponseWriter, req *http.Request) {
+	requestDump, err := httputil.DumpRequest(req, true)
+	if err != nil {
+		fmt.Fprint(w, err.Error())
+	} else {
+		fmt.Fprint(w, string(requestDump))
+	}
+}
+
 // CreateVehicle takes a vehicle and creates it in hexon,
 // returning the api response and an error if one occurred.
 func (c *Client) CreateVehicle(vehicle Vehicle) (*APIResponse, error) {
@@ -70,6 +81,9 @@ func (c *Client) CreateVehicle(vehicle Vehicle) (*APIResponse, error) {
 		return nil, err
 	}
 	log.Println(req)
+	b, err := httputil.DumpRequest(req, true)
+	n := bytes.IndexByte(b, 0)
+	log.Println(n)
 	return c.send(req)
 }
 
@@ -87,6 +101,9 @@ func (c *Client) PublishVehicle(vin, sitecode string) (*APIResponse, error) {
 	}
 	log.Println(msg)
 	log.Println(req)
+	b, err := httputil.DumpRequest(req, true)
+	n := bytes.IndexByte(b, 0)
+	log.Println(n)
 	return c.send(req)
 }
 

--- a/client.go
+++ b/client.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
-	"net/http/httputil"
 	"time"
 )
 
@@ -70,12 +68,6 @@ func (c *Client) CreateVehicle(vehicle Vehicle) (*APIResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Println(req)
-	b, err := httputil.DumpRequest(req, true)
-	n := bytes.IndexByte(b, 0)
-	log.Println(n)
-	log.Println("correct print")
-	fmt.Printf("%08b", b)
 	return c.send(req)
 }
 
@@ -91,13 +83,6 @@ func (c *Client) PublishVehicle(vin, sitecode string) (*APIResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Println(msg)
-	log.Println(req)
-	b, err := httputil.DumpRequest(req, true)
-	n := bytes.IndexByte(b, 0)
-	log.Println(n)
-	log.Println("correct print")
-	fmt.Printf("%08b", b)
 	return c.send(req)
 }
 

--- a/client.go
+++ b/client.go
@@ -63,16 +63,6 @@ type Client struct {
 	http     http.Client
 }
 
-// Dump request for printing and testing
-func DumpRequest(w http.ResponseWriter, req *http.Request) {
-	requestDump, err := httputil.DumpRequest(req, true)
-	if err != nil {
-		fmt.Fprint(w, err.Error())
-	} else {
-		fmt.Fprint(w, string(requestDump))
-	}
-}
-
 // CreateVehicle takes a vehicle and creates it in hexon,
 // returning the api response and an error if one occurred.
 func (c *Client) CreateVehicle(vehicle Vehicle) (*APIResponse, error) {
@@ -84,6 +74,8 @@ func (c *Client) CreateVehicle(vehicle Vehicle) (*APIResponse, error) {
 	b, err := httputil.DumpRequest(req, true)
 	n := bytes.IndexByte(b, 0)
 	log.Println(n)
+	log.Println("correct print")
+	fmt.Printf("%08b", b)
 	return c.send(req)
 }
 
@@ -104,6 +96,8 @@ func (c *Client) PublishVehicle(vin, sitecode string) (*APIResponse, error) {
 	b, err := httputil.DumpRequest(req, true)
 	n := bytes.IndexByte(b, 0)
 	log.Println(n)
+	log.Println("correct print")
+	fmt.Printf("%08b", b)
 	return c.send(req)
 }
 

--- a/hexonvehicle.go
+++ b/hexonvehicle.go
@@ -29,6 +29,7 @@ type pricedetails struct {
 type price struct {
 	Currency string       `json:"currency"`
 	Consumer pricedetails `json:"consumer"`
+	Trade    pricedetails `json:"trade"`
 }
 
 type salescondition struct {
@@ -99,6 +100,10 @@ func payloadify(vehicle Vehicle) hexonvehicle {
 				Currency: vehicle.Currency,
 				Consumer: pricedetails{
 					Value:       vehicle.PriceIncludingVat,
+					IncludesVAT: true,
+				},
+				Trade: pricedetails{
+					Value:       vehicle.TradePriceIncludingVat,
 					IncludesVAT: true,
 				},
 			},

--- a/hexonvehicle.go
+++ b/hexonvehicle.go
@@ -77,7 +77,7 @@ type hexonvehicle struct {
 	Condition      condition      `json:"condition"`
 	History        history        `json:"history"`
 	Body           body           `json:"body"`
-	PowerTrain     powertrain     `json:"power_train"`
+	PowerTrain     powertrain     `json:"powertrain"`
 }
 
 func payloadify(vehicle Vehicle) hexonvehicle {

--- a/hexonvehicle.go
+++ b/hexonvehicle.go
@@ -57,6 +57,18 @@ type body struct {
 	Color color `json:"colour"`
 }
 
+type powertrain struct {
+	Engine engine `json:"engine"`
+}
+
+type engine struct {
+	Energy energy `json:"energy"`
+}
+
+type energy struct {
+	Type string `json:"type"`
+}
+
 type hexonvehicle struct {
 	StockNumber    string         `json:"stocknumber"`
 	Identification identification `json:"identification"`
@@ -65,6 +77,7 @@ type hexonvehicle struct {
 	Condition      condition      `json:"condition"`
 	History        history        `json:"history"`
 	Body           body           `json:"body"`
+	PowerTrain     powertrain     `json:"power_train"`
 }
 
 func payloadify(vehicle Vehicle) hexonvehicle {
@@ -104,6 +117,13 @@ func payloadify(vehicle Vehicle) hexonvehicle {
 		},
 		History: history{
 			ArrivalDate: vehicle.ExpectedDateAvailable.Format("2006-01-02"),
+		},
+		PowerTrain: powertrain{
+			Engine: engine{
+				Energy: energy{
+					Type: vehicle.FuelType,
+				},
+			},
 		},
 	}
 }

--- a/util.go
+++ b/util.go
@@ -1,10 +1,10 @@
 package hexon
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"regexp"
-	"strings"
 )
 
 //Common Errors
@@ -25,7 +25,7 @@ func isValidVin(vin string) bool {
 }
 
 func concatErrors(msg string, errs ...error) error {
-	buidler := strings.Builder{}
+	buidler := bytes.Buffer{}
 	buidler.WriteString(fmt.Sprintf("%s:\n", msg))
 	for i, err := range errs {
 		buidler.WriteString(fmt.Sprintf("%d. %s\n", i, err))

--- a/vehicle.go
+++ b/vehicle.go
@@ -4,20 +4,21 @@ import "time"
 
 //The Vehicle struct models a car with attributes used in hexon
 type Vehicle struct {
-	Vin                   string
-	LicenseNumber         string
-	LocationCode          string
-	Make                  string
-	Model                 string
-	BodyStyle             string
-	HexonCategory         string
-	Currency              string
-	ExpectedDateAvailable time.Time
-	PriceIncludingVat     float64
-	IsNewCar              bool
-	ExpectedMileage       int
-	MileageUnit           string
-	ExteriorColor         string
-	FuelType              string
-	IsVatDeductible       bool
+	Vin                     string
+	LicenseNumber           string
+	LocationCode            string
+	Make                    string
+	Model                   string
+	BodyStyle               string
+	HexonCategory           string
+	Currency                string
+	ExpectedDateAvailable   time.Time
+	PriceIncludingVat       float64
+	TradePriceIncludingVat  float64
+	IsNewCar                bool
+	ExpectedMileage         int
+	MileageUnit             string
+	ExteriorColor           string
+	FuelType                string
+	IsVatDeductible         bool
 }


### PR DESCRIPTION
Fuel type was available in the vehicle struct, but not in the hexonvehicle struct. Thus, when the hexonvehicle struct gets filled to create the JSON it did not include the fuel type of this car. This caused Hexon to mark all fuel types as 'O'.

I added the fuel type (powertrain > engine > energy > type) to hexonvehicle.